### PR TITLE
feat(name getter): added helper for getting component name

### DIFF
--- a/src/getComponentName.js
+++ b/src/getComponentName.js
@@ -1,0 +1,32 @@
+import invariant from "invariant";
+
+/**
+ * Identify the name to use for a component by inspecting a component's static 'displayName' or 'name' properties.
+ * @param {Function|String} componentOrName A component with a 'name' or 'displayName' property or the component name
+ * as a string OR an explicit string name for the component.
+ * @returns {String} The name to use for the component's semantic class names.
+ */
+export default function getComponentName(componentOrName) {
+  if (typeof componentOrName === "function") {
+    invariant(
+      componentOrName.displayName || componentOrName.name,
+      "When supplying a component to the class name helper, it must have either a 'displayName' or 'name' property"
+    );
+  } else {
+    invariant(
+      componentOrName && typeof componentOrName === "string",
+      "A component name must be supplied to the class name helper as a string or as a named function/Component with a 'displayName' or 'name' property."
+    );
+  }
+  const componentName = (typeof componentOrName === "string"
+    ? componentOrName
+    : componentOrName.displayName
+    ? componentOrName.displayName
+    : componentOrName.name
+  ).trim();
+  invariant(
+    !!componentName,
+    `Expected to resolve a non-empty component name. After trimming whitespace, found '${componentName}'`
+  );
+  return componentName;
+}

--- a/src/getComponentName.test.js
+++ b/src/getComponentName.test.js
@@ -1,0 +1,45 @@
+import getComponentName from "./getComponentName";
+
+describe("getComponentName", () => {
+  it("should resolve a component's display name", () => {
+    const component = () => {};
+    component.displayName = "MyComponent";
+    expect(getComponentName(component)).toEqual(component.displayName);
+  });
+
+  it("should resolve a function's name if the component does not have a display name", () => {
+    function MyComponent() {}
+    expect(getComponentName(MyComponent)).toEqual("MyComponent");
+  });
+
+  it("should resolve the component's class name for class components", () => {
+    class MyComponent {}
+    expect(getComponentName(MyComponent)).toEqual("MyComponent");
+  });
+
+  it("should just return the component's string name when supplied as a string, meaning the caller has supplied an explicit name", () => {
+    const expectedName = "MyComponent";
+    expect(getComponentName(expectedName)).toEqual(expectedName);
+  });
+
+  it("should throw for unnamed functions", () => {
+    expect(() => {
+      getComponentName(() => {});
+    }).toThrow();
+  });
+
+  it("should throw for input other than components and non-empty names as strings", () => {
+    expect(() => {
+      getComponentName(null);
+    }).toThrow();
+    expect(() => {
+      getComponentName();
+    }).toThrow();
+    expect(() => {
+      getComponentName("");
+    }).toThrow();
+    expect(() => {
+      getComponentName("  ");
+    }).toThrow();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,39 @@
+import invariant from "invariant";
+import warning from "warning";
+import getComponentName from "./getComponentName";
+
+/**
+ * A helper that will provide class names for a component's root or sub elements. Accepts objects for specifying
+ * conditional modifiers. Generated class names will contain BEM identifiers.
+ */
+class ClassNameHelper {
+  /**
+   *
+   * @param {Function|String} componentOrName A component with a 'name' or 'displayName' property or the component name
+   * as a string.
+   * @param {Object} [props=null] The component's props.
+   * @param {Object} [props.classes=null] Classnames provided to the component as a part of it's CSS API, most likely
+   * from Material-UI's withStyles or JSS.
+   */
+  constructor(componentOrName, props = null) {
+    this.componentName = getComponentName(componentOrName);
+    warning(
+      !props ||
+        (props.hasOwnProperty("classes") && typeof props.classes === "object"),
+      "When props are provided, the classname helper expects to receive an object of 'classes' on props to select a component's CSS API. This helper assumes you're using CSS in JS patterns, are you using JSS or MUI withStyles() correctly?"
+    );
+    this.props = props;
+  }
+}
+
+export default function createClassNameHelper(componentOrName, props) {
+  if (arguments.length === 1) {
+    const curried = props => createClassNameHelper(componentOrName, props);
+    return Object.assign(curried, new ClassNameHelper(componentOrName));
+  }
+  invariant(
+    props && typeof props === "object",
+    "The classname helper expects to receive an object of props to select class names for a component's CSS API"
+  );
+  return new ClassNameHelper(componentOrName, props);
+}


### PR DESCRIPTION
**Background and Summary:**
The first step in creating the helper should include the definition of the ClassNameHelper class and a helper for getting a component name.

**Solution:**
* Removed a 'src' file added in error
* Added 'src' directory
* Added index.js and defined the classNameHelper class and default export of createClassNameHelper
* Added helper, getComponentName, that takes in a component or a string and returns either that string or the component's display name or name
* Added tests for the getComponentName helper