### PR TITLE
feat(unique names): added helper for getting unique class names

### DIFF
--- a/src/uniqueClassnames.js
+++ b/src/uniqueClassnames.js
@@ -1,0 +1,14 @@
+import classnames from "classnames";
+import uniq from "lodash/uniq";
+
+/**
+ * Identical to the 'classnames' library, with the exception that it removes redundant class names and only returns
+ * an array of unique names.
+ * @param {Array<Object|Array|String>} args
+ * @returns {Array}
+ * @see (@link https://github.com/JedWatson/classnames)
+ */
+export default function uniqueClassnames(...args) {
+  const names = classnames(...args);
+  return names ? uniq(names.split(" ")) : [];
+}

--- a/src/uniqueClassnames.test.js
+++ b/src/uniqueClassnames.test.js
@@ -1,0 +1,17 @@
+import uniqueClassnames from "./uniqueClassnames";
+
+describe("uniqueClassnames", () => {
+  it("should return unique names", () => {
+    expect(uniqueClassnames("foo", { foo: true })).toEqual(["foo"]);
+    expect(uniqueClassnames(["foo", "foo"])).toEqual(["foo"]);
+    expect(uniqueClassnames("foo foo")).toEqual(["foo"]);
+  });
+
+  it("should filter out falsy conditionals", () => {
+    expect(uniqueClassnames("foo", { bar: false })).toEqual(["foo"]);
+  });
+
+  it("should handle nulls, empty conditionals, etc", () => {
+    expect(uniqueClassnames({}, null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
**Background and Summary:**
Any duplicate class names in a generated list should be removed.

**Solution:**
* Created a helper called uniqueClassnames that returns an array of class names.  The helper passes a set of arguments to the classnames library and then uses lodash's uniq method to remove any duplicates generated
* Added tests for the uniqueClassnames helper