### PR TITLE
feat(css api names): added helper for getting css api class names

### DIFF
--- a/src/getCSSAPIClassnames.js
+++ b/src/getCSSAPIClassnames.js
@@ -1,0 +1,42 @@
+import warning from "warning";
+import { get, camelCase } from "lodash";
+import listClasses from "./listClasses";
+import uniqueClassnames from "./uniqueClassnames";
+
+/**
+ * Retrieve the CSS API class names (from props.classes) that correspond to the provided modifiers and optional sub
+ * element. When a sub element is provided, an element's modifier class name will be pulled from 'classes' at a property
+ * camelCase(elementName, modifierName).
+ * @param {Object} [props={}] A component's props.
+ * @param {Object} [props.classes={}] A component's CSS API.
+ * @param {Object} [modifiers={}] An object specifying possible modifier class names (the keys) and whether they
+ * should be applied (the values).
+ * @param {String} [elementName=null] A String identifiying the BEM sub-element that's being modified
+ * @returns {Array} An array of classnames drawn from props.classes by evaluating conditional 'modifiers'
+ */
+export default function getCSSAPIClassnames(
+  props = {},
+  modifiers = {},
+  elementName = null
+) {
+  const classes = get(props, "classes", {});
+  return uniqueClassnames(
+    Object.keys(modifiers).reduce((accum, modifierName) => {
+      const modifierCSSAPIName = elementName
+        ? camelCase([elementName, modifierName])
+        : modifierName;
+      warning(
+        !props ||
+          (classes.hasOwnProperty(modifierCSSAPIName) &&
+            typeof classes[modifierCSSAPIName] === "string"),
+        `Expected props.classes to have a property '${modifierCSSAPIName}' for the modifier of the same name. Are you applying modifiers that aren't a part of your CSS API? ${listClasses(
+          classes
+        )}`
+      );
+      return {
+        ...accum,
+        [classes[modifierCSSAPIName]]: modifiers[modifierName]
+      };
+    }, {})
+  );
+}

--- a/src/getCSSAPIClassnames.test.js
+++ b/src/getCSSAPIClassnames.test.js
@@ -1,0 +1,99 @@
+import getCSSAPIClassnames from "./getCSSAPIClassnames";
+import { camelCase } from "lodash";
+
+it("should handle optional props and classes", () => {
+  expect(getCSSAPIClassnames(null, {})).toEqual([]);
+  expect(getCSSAPIClassnames({}, {})).toEqual([]);
+  expect(getCSSAPIClassnames({ classes: {} }, {})).toEqual([]);
+});
+
+it("should map modifiers to CSS API names", () => {
+  const props = {
+    classes: {
+      foo: "foo-generated",
+      bar: "bar-generated"
+    }
+  };
+  const modifiers = {
+    foo: true,
+    bar: false
+  };
+  expect(getCSSAPIClassnames(props, modifiers)).toEqual(["foo-generated"]);
+});
+
+it("should map element modifiers to CSS API names using a camel case convention", () => {
+  const props = {
+    classes: {
+      foo: "foo-generated",
+      someElementFoo: "some-element-foo-generated",
+      bar: "bar-generated",
+      someElementBar: "some-element-bar-generated"
+    }
+  };
+  const modifiers = {
+    foo: true,
+    bar: false
+  };
+  expect(getCSSAPIClassnames(props, modifiers, "someElement")).toEqual([
+    "some-element-foo-generated"
+  ]);
+});
+
+it("should log an error if no elementName is provided and the classes object passed does not include a property matching a provided modifier", () => {
+  const props = {
+    classes: {
+      foo: "foo-generated"
+    }
+  };
+  const modifiers = {
+    bar: true
+  };
+  console.error = jest.fn();
+  getCSSAPIClassnames(props, modifiers, null);
+  expect(console.error).toHaveBeenCalled();
+});
+
+it("should log an error if an elementName is provided and the classes object passed does not include a property matching a camelcase concatenation of the element name and provided modifier", () => {
+  const props = {
+    classes: {
+      foo: "foo-generated"
+    }
+  };
+  const modifiers = {
+    bar: true
+  };
+  console.error = jest.fn();
+  getCSSAPIClassnames(props, modifiers, "elementName");
+  expect(console.error).toHaveBeenCalled();
+});
+
+it("should not log an error if no elementName is provided and the classes object passed includes a property matching a provided modifier", () => {
+  const props = {
+    classes: {
+      foo: "foo-generated"
+    }
+  };
+  const modifiers = {
+    foo: true
+  };
+  console.error = jest.fn();
+  getCSSAPIClassnames(props, modifiers, null);
+  expect(console.error).not.toHaveBeenCalled();
+});
+
+it("should not log an error if an elementName is provided and the classes object passed does include a property matching a camelcase concatenation of the element name and provided modifier", () => {
+  const elementName = "elementName";
+  const modifierName = "bar";
+  const props = {
+    classes: {
+      foo: "foo-generated",
+      [camelCase([elementName, modifierName])]: "elementNameBar-generated"
+    }
+  };
+  const modifiers = {
+    bar: true
+  };
+  console.error = jest.fn();
+  getCSSAPIClassnames(props, modifiers, elementName);
+  expect(console.error).not.toHaveBeenCalled();
+});

--- a/src/listClasses.js
+++ b/src/listClasses.js
@@ -1,0 +1,5 @@
+export default function listClasses(classes) {
+  return `The classes provided in props are ['${Object.keys(classes).join(
+    "', '"
+  )}']`;
+}


### PR DESCRIPTION
**Background and Summary:**
The classnames helper should have a helper method to validate that a consumer is passing CSS API class names in the expected format.

**Solution:**
* Added helper, getCSSAPIClassnames, which takes in values for props, modifiers, and an element name, and verifies that the consumer has provided CSS API class names in the expected format
* Added tests for the getCSSAPIClassnames helper
* Added utility method, listClasses, for supporting messaging in warning to a consumer that has not provided class names in the expected format 