### PR TITLE
feat(bem class names): added BEM helper and root / element methods

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,4 @@
 {
-  "extends": [
-    "react-app",
-    "plugin:prettier/recommended"
-  ],
-  "plugins": [
-    "json"
-  ]
+  "extends": ["react-app", "plugin:prettier/recommended"],
+  "plugins": ["json"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+Changelog.md
+yarn.lock
+.history
+CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -1,63 +1,67 @@
 {
-    "name": "classnames-helper",
-    "version": "1.0.0",
-    "description": "A companion tool for React components that eases the burden of implementing a component's CSS API in tandem with BEM identifiers.",
-    "license": "UNLICENSED",
-    "repository": "https://github.com/n-bryant/classnames-helper.git",
-    "main": "dist/index.js",
-    "module": "dist/index.es.js",
-    "jsnext:main": "dist/index.es.js",
-    "scripts": {
-        "build": "yarn lint && rm -rf dist && rollup -c --environment BUILD:production",
-        "commitmsg": "commitlint -e $GIT_PARAMS",
-        "lint": "eslint .",
-        "precommit": "lint-staged",
-        "start": "rollup -c -w",
-        "test": "react-scripts test --env=jsdom"
-    },
-    "dependencies": {
-        "@commitlint/cli": "^7.0.0",
-        "bem-helper-js": "^1.0.2",
-        "classnames": "^2.2.6",
-        "invariant": "^2.2.4",
-        "warning": "^4.0.2"
-    },
-    "peerDependencies": {
-        "lodash": "^4.17.11"
-    },
-    "devDependencies": {
-        "@commitlint/cli": "^7.0.0",
-        "@commitlint/config-conventional": "^7.0.1",
-        "babel-core": "^6.26.3",
-        "babel-loader": "^7.1.4",
-        "babel-plugin-external-helpers": "^6.22.0",
-        "babel-plugin-syntax-dynamic-import": "^6.18.0",
-        "babel-preset-env": "^1.7.0",
-        "babel-preset-stage-0": "^6.24.1",
-        "eslint-config-prettier": "^2.9.0",
-        "eslint-plugin-json": "^1.2.0",
-        "eslint-plugin-prettier": "^2.6.1",
-        "husky": "^0.14.3",
-        "lint-staged": "^7.2.0",
-        "lodash": "^4.17.11",
-        "prettier": "^1.13.6",
-        "react-scripts": "^1.1.4",
-        "rollup": "^0.54.0",
-        "rollup-plugin-babel": "^3.0.3",
-        "rollup-plugin-commonjs": "^8.2.1",
-        "rollup-plugin-node-builtins": "^2.1.2",
-        "rollup-plugin-node-globals": "^1.4.0",
-        "rollup-plugin-node-resolve": "^3.0.2",
-        "rollup-plugin-peer-deps-external": "^2.0.0",
-        "rollup-plugin-url": "^1.3.0"
-    },
-    "files": [
-        "dist"
-    ],
-    "lint-staged": {
-        "*.{js,json}": [
-            "eslint --fix",
-            "git add"
-        ]
-    }
+  "name": "classnames-helper",
+  "version": "1.0.0",
+  "description": "A companion tool for React components that eases the burden of implementing a component's CSS API in tandem with BEM identifiers.",
+  "repository": "https://github.com/n-bryant/classnames-helper.git",
+  "license": "UNLICENSED",
+  "files": [
+    "dist"
+  ],
+  "main": "dist/index.js",
+  "module": "dist/index.es.js",
+  "jsnext:main": "dist/index.es.js",
+  "scripts": {
+    "build": "yarn lint && rm -rf dist && rollup -c --environment BUILD:production",
+    "commitmsg": "commitlint -e $GIT_PARAMS",
+    "lint": "yarn lint:eslint && yarn lint:prettier && yarn lint:sort-package-json",
+    "lint:eslint": "eslint . --cache --ext .js,.jsx --fix",
+    "lint:prettier": "prettier '**/*.{css,scss,sass,less,json,yml,yaml,html,md,mdx,vue,ts,tsx,gql,graphql}' --write",
+    "lint:sort-package-json": "sort-package-json",
+    "precommit": "lint-staged",
+    "start": "rollup -c -w",
+    "test": "react-scripts test --env=jsdom"
+  },
+  "lint-staged": {
+    "*.{js,json}": [
+      "eslint --fix",
+      "git add"
+    ]
+  },
+  "dependencies": {
+    "@commitlint/cli": "^7.0.0",
+    "bem-helper-js": "^1.0.2",
+    "classnames": "^2.2.6",
+    "invariant": "^2.2.4",
+    "warning": "^4.0.2"
+  },
+  "devDependencies": {
+    "@commitlint/cli": "^7.0.0",
+    "@commitlint/config-conventional": "^7.0.1",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.4",
+    "babel-plugin-external-helpers": "^6.22.0",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
+    "babel-preset-env": "^1.7.0",
+    "babel-preset-stage-0": "^6.24.1",
+    "eslint-config-prettier": "^2.9.0",
+    "eslint-plugin-json": "^1.2.0",
+    "eslint-plugin-prettier": "^2.6.1",
+    "husky": "^0.14.3",
+    "lint-staged": "^7.2.0",
+    "lodash": "^4.17.11",
+    "prettier": "^1.13.6",
+    "react-scripts": "^1.1.4",
+    "rollup": "^0.54.0",
+    "rollup-plugin-babel": "^3.0.3",
+    "rollup-plugin-commonjs": "^8.2.1",
+    "rollup-plugin-node-builtins": "^2.1.2",
+    "rollup-plugin-node-globals": "^1.4.0",
+    "rollup-plugin-node-resolve": "^3.0.2",
+    "rollup-plugin-peer-deps-external": "^2.0.0",
+    "rollup-plugin-url": "^1.3.0",
+    "sort-package-json": "^1.22.1"
+  },
+  "peerDependencies": {
+    "lodash": "^4.17.11"
+  }
 }

--- a/src/getBEMModifierClassnames.js
+++ b/src/getBEMModifierClassnames.js
@@ -1,0 +1,26 @@
+import uniqueClassnames from "./uniqueClassnames";
+
+/**
+ * Using a bem-helper-js builder, reduce an object of conditional modifiers into an array of BEM modifier classnames
+ * @param {Function} bemBuilderFactory A function that returns a bem-helper-js builder with the right scoping.
+ * @param {Object} [modifiers={}] An object specifying possible modifier class names (the keys) and whether they
+ * should be applied (the values).
+ * @returns {Array} An array of class names
+ */
+export default function getBEMModifierClassnames(
+  bemBuilderFactory,
+  modifiers = {}
+) {
+  return uniqueClassnames(
+    Object.keys(modifiers).reduce(
+      (accum, modifierName) => [
+        ...accum,
+        ...bemBuilderFactory()
+          .is(modifierName, modifiers[modifierName])
+          .toString()
+          .split(" ")
+      ],
+      []
+    )
+  );
+}

--- a/src/getBEMModifierClassnames.test.js
+++ b/src/getBEMModifierClassnames.test.js
@@ -1,0 +1,70 @@
+import getBEMModifierClassnames from "./getBEMModifierClassnames";
+import BEM from "bem-helper-js";
+import classnamesHelper from "classnames";
+
+const classNamesAsArray = names => classnamesHelper(names).split(" ");
+
+const countClassnames = namesArray =>
+  namesArray.reduce(
+    (counts, name) => ({
+      ...counts,
+      [name]: (counts[name] || 0) + 1
+    }),
+    {}
+  );
+
+const hasRedundantNames = namesArray =>
+  Object.values(countClassnames(namesArray)).filter(count => count > 1).length >
+  0;
+
+describe("test helpers", () => {
+  describe("hasRedundantNames", () => {
+    it("should count redundant class names", () => {
+      expect(hasRedundantNames(["foo", "foo", "bar"])).toBe(true);
+      expect(hasRedundantNames(["foo", "bar"])).toBe(false);
+      expect(hasRedundantNames([])).toBe(false);
+    });
+  });
+  describe("countClassnames", () => {
+    it("should count class names", () => {
+      expect(countClassnames(["foo", "foo", "bar"])).toEqual({
+        foo: 2,
+        bar: 1
+      });
+      expect(countClassnames(["foo", "bar"])).toEqual({
+        foo: 1,
+        bar: 1
+      });
+      expect(countClassnames([])).toEqual({});
+    });
+  });
+});
+
+it("should not provide redundant class names", () => {
+  const builder = () => BEM("MyComponent");
+
+  const bemHelperNames = classNamesAsArray(
+    [
+      builder()
+        .is("foo")
+        .toString(),
+      builder()
+        .is("bar")
+        .toString()
+    ].join(" ")
+  );
+
+  // Sanity check, this asserts that the BEM helper is providing redundant class names.
+  // This asserts that at least one class name shows up twice.
+  expect(hasRedundantNames(bemHelperNames)).toBe(true);
+
+  const classNames = classNamesAsArray(
+    getBEMModifierClassnames(builder, {
+      foo: true,
+      bar: true
+    })
+  );
+
+  expect(hasRedundantNames(classNames)).toBe(false);
+  expect(new Set(classNames)).toEqual(new Set(bemHelperNames));
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,17 @@
 import invariant from "invariant";
 import warning from "warning";
+import BEM from "bem-helper-js";
+import get from "lodash/get";
 import getComponentName from "./getComponentName";
+import getBEMModifierClassnames from "./getBEMModifierClassnames";
+import getCSSAPIClassnames from "./getCSSAPIClassnames";
+import uniqueClassnames from "./uniqueClassnames";
 
 /**
- * A helper that will provide class names for a component's root or sub elements. Accepts objects for specifying
+ * A generator that will provide class names for a component's root or sub elements. Accepts objects for specifying
  * conditional modifiers. Generated class names will contain BEM identifiers.
  */
-class ClassNameHelper {
+class ClassNameGenerator {
   /**
    *
    * @param {Function|String} componentOrName A component with a 'name' or 'displayName' property or the component name
@@ -20,20 +25,86 @@ class ClassNameHelper {
     warning(
       !props ||
         (props.hasOwnProperty("classes") && typeof props.classes === "object"),
-      "When props are provided, the classname helper expects to receive an object of 'classes' on props to select a component's CSS API. This helper assumes you're using CSS in JS patterns, are you using JSS or MUI withStyles() correctly?"
+      "When props are provided, the classname generator expects to receive an object of 'classes' on props to select a component's CSS API. This generator assumes you're using CSS in JS patterns, are you using JSS or MUI withStyles() correctly?"
     );
     this.props = props;
   }
+
+  /**
+   * Generates class names for the component's root, conditionally applying modifiers according to their conditions.
+   * @type {Function}
+   * @param {Object} [modifiers={}] An object specifying possible modifier class names (the keys) and whether they
+   * should be applied (the values).
+   * @returns {String}
+   */
+  root = (modifiers = {}) => {
+    const modifierBEMNames = getBEMModifierClassnames(
+      () => BEM(this.componentName),
+      modifiers
+    );
+
+    const cssAPIRootModifierClassNames = getCSSAPIClassnames(
+      this.props,
+      modifiers
+    );
+    return uniqueClassnames(
+      BEM(this.componentName).toString(),
+      modifierBEMNames,
+      get(this.props, "className"),
+      get(this.props, "classes.root"),
+      cssAPIRootModifierClassNames
+    ).join(" ");
+  };
+
+  /**
+   * Generates class names for the component's named sub element, conditionally applying modifiers to the element
+   * according to their conditions.
+   * @type {Function}
+   * @param {String} elementName
+   * @param {Object} [modifiers={}] An object specifying possible modifier class names (the keys) and whether they
+   * should be applied (the values).
+   * @returns {String}
+   */
+  element = (elementName, modifiers = {}) => {
+    invariant(
+      elementName && typeof elementName === "string",
+      "Expected to generate class names for a named sub element. Required a string element name."
+    );
+
+    const modifierBEMNames = getBEMModifierClassnames(
+      () => BEM(this.componentName).el(elementName),
+      modifiers
+    );
+    const cssAPIElementModifierClassNames = getCSSAPIClassnames(
+      this.props,
+      modifiers,
+      elementName
+    );
+    const cssAPIElementClassName = get(this.props, ["classes", elementName]);
+    warning(
+      !this.props ||
+        (cssAPIElementClassName && typeof cssAPIElementClassName === "string"),
+      `Expected props.classes to have property '${elementName}' to represent the sub element of the same name. Are you identifying elements that aren't a part of your CSS API?`
+    );
+    return uniqueClassnames(
+      BEM(this.componentName)
+        .el(elementName)
+        .toString(),
+      modifierBEMNames,
+      cssAPIElementClassName,
+      cssAPIElementModifierClassNames
+    ).join(" ");
+  };
 }
 
-export default function createClassNameHelper(componentOrName, props) {
+export default function createClassNameGenerator(componentOrName, props) {
   if (arguments.length === 1) {
-    const curried = props => createClassNameHelper(componentOrName, props);
-    return Object.assign(curried, new ClassNameHelper(componentOrName));
+    const curried = props => createClassNameGenerator(componentOrName, props);
+    return Object.assign(curried, new ClassNameGenerator(componentOrName));
   }
   invariant(
     props && typeof props === "object",
-    "The classname helper expects to receive an object of props to select class names for a component's CSS API"
+    "The classname generator expects to receive an object of props to select class names for a component's CSS API"
   );
-  return new ClassNameHelper(componentOrName, props);
+  return new ClassNameGenerator(componentOrName, props);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2818,6 +2818,11 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-indent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-5.0.0.tgz#3871cc0a6a002e8c3e5b3cf7f336264675f06b9d"
+  integrity sha1-OHHMCmoALow+Wzz38zYmRnXwa50=
+
 detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
@@ -8426,6 +8431,19 @@ sort-keys@^1.0.0:
   integrity sha1-RBttTTRnmPG05J6JIK37oOVD+a0=
   dependencies:
     is-plain-obj "^1.0.0"
+
+sort-object-keys@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sort-object-keys/-/sort-object-keys-1.1.2.tgz#d3a6c48dc2ac97e6bc94367696e03f6d09d37952"
+  integrity sha1-06bEjcKsl+a8lDZ2luA/bQnTeVI=
+
+sort-package-json@^1.22.1:
+  version "1.22.1"
+  resolved "https://registry.yarnpkg.com/sort-package-json/-/sort-package-json-1.22.1.tgz#384ce7a098cd13be4109800d5ce2f0cf7826052e"
+  integrity sha512-uVINQraFQvnlzNHFnQOT4MYy0qonIEzKwhrI2yrTiQjNo5QF4h3ffrnCk7a95QAwoK/RdkO/w8W9tJIcaOWC7g==
+  dependencies:
+    detect-indent "^5.0.0"
+    sort-object-keys "^1.1.2"
 
 source-list-map@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
**Background and Summary:**
A helper for creating a list of BEM class names, adding modifiers to the names based on an object of boolean modifier values.

**Solution:**
* Created helper, getBEMModifierClassnames, that takes in bem-helper-js and an object of boolean modifier values and returns a list of BEM class names
* Added tests for the getBEMModifierClassnames helper
* Added root and element methods to the ClassNameHelper class that return class names for a component's root or sub element
* Adjusted some tooling